### PR TITLE
Fix README reference to report.py

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -106,8 +106,7 @@ portfolio_project/
 │  └─ portfolio/                               ← importable package
 │     ├─ __init__.py
 │     ├─ core.py                               ← simulate_portfolio, identify_windows, calc_window_returns
-│     ├─ plots.py                              ← boxplot_returns and visualisation utilities
-│     └─ report.py                             ← (future) output formatting or summarisation
+│     └─ report.py                             ← boxplot_returns and visualisation utilities
 │
 ├─ tests/
 │  ├─ test_smoke.py                            ← integration test matching the manual run


### PR DESCRIPTION
## Summary
- link to `report.py` in module tree in place of removed `plots.py`
- ensure README ends with a newline

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_684f2daa46a0832497ab1a1c8f787a8b