### PR TITLE
Add dividend tests for simulate_portfolio

### DIFF
--- a/tests/test_simulate_portfolio_dividend.py
+++ b/tests/test_simulate_portfolio_dividend.py
@@ -1,0 +1,16 @@
+import pandas as pd
+import pytest
+
+from portfolio import simulate_portfolio
+
+
+def test_simulate_portfolio_raises_for_dividend_true():
+    df = pd.DataFrame({'sp_real_price': [100, 110]})
+    with pytest.raises(NotImplementedError):
+        simulate_portfolio(df, leverage=1, dividend=True)
+
+
+def test_simulate_portfolio_no_dividend_runs():
+    df = pd.DataFrame({'sp_real_price': [100, 110]})
+    out = simulate_portfolio(df, leverage=1, dividend=False)
+    assert out['portfolio_1x'].tolist() == [1.0, 1.1]


### PR DESCRIPTION
## Summary
- add regression tests covering dividend flag behavior in `simulate_portfolio`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6851e62461288324a74939a961326ae1