### PR TITLE
Refactor bust detection

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,7 +1,15 @@
 #!/usr/bin/env python
 import argparse
 import pandas as pd
-from portfolio import simulate_portfolio, calc_window_returns, boxplot_returns, name_run_output, identify_windows, simulate_window
+from portfolio import (
+    simulate_portfolio,
+    calc_window_returns,
+    boxplot_returns,
+    name_run_output,
+    identify_windows,
+    simulate_window,
+    detect_bust,
+)
 import matplotlib.pyplot as plt
 import os
 from datetime import datetime
@@ -24,7 +32,7 @@ def main(args):
     )
     returns.to_csv(name_run_output('returns',args.out, args.leverage, "csv"))
 
-    if args.plot:
+    if getattr(args, "plot", False):
         fig = boxplot_returns(
             returns,
             [f"portfolio_{lev}x_returns" for lev in args.leverage],
@@ -46,7 +54,7 @@ def main(args):
 
     windows = identify_windows(data, window_size=args.window)
 
-    cols = [args.datecol] + [f"portfolio_{lev}x_returns" for lev in args.leverage]
+    cols = [args.datecol] + [f"portfolio_{lev}x" for lev in args.leverage]
     returns_df = pd.DataFrame(columns=cols)
     annualised_returns_df = pd.DataFrame(columns=cols)
 
@@ -55,77 +63,100 @@ def main(args):
     for lev in args.leverage:
         for start_idx, end_idx in windows:
             # slice prices for this window (inclusive of end_idx)
-            #prices = data.loc[start_idx:end_idx, args.pricecol]
-            prices = data.iloc[start_idx:end_idx, data.columns.get_loc(args.pricecol)]
+            # prices = data.loc[start_idx:end_idx, args.pricecol]
+            prices = data.iloc[
+                start_idx : end_idx + 1,
+                data.columns.get_loc(args.pricecol),
+            ]
 
             # run the recursion
             V_path = simulate_window(prices, leverage=lev)
 
             # detect bust
-            if (V_path <= 0).any():
+            if detect_bust(V_path):
                 bust_counter[lev] += 1
-                window_ret  = 0.0
-                window_ann  = 0.0
+                window_ret = 0.0
+                window_ann = 0.0
             else:
                 window_ret = V_path[-1] / V_path[0] - 1.0
-                years      = (len(prices) - 1) / 12       # 12-month year
-                window_ann = (V_path[-1] / V_path[0]) ** (1/years) - 1.0
+                years = (len(prices) - 1) / 252
+                window_ann = (V_path[-1] / V_path[0]) ** (1 / years) - 1.0
 
             # label row by first date in window
             win_label = data.loc[start_idx, args.datecol]
 
             # append (or update) rows
-            for df, value in ((returns_df, window_ret),
-                              (annualised_returns_df, window_ann)):
+            for df, value in (
+                (returns_df, window_ret),
+                (annualised_returns_df, window_ann),
+            ):
                 if win_label not in df[args.datecol].values:
                     df.loc[len(df), args.datecol] = win_label
-                df.loc[df[args.datecol] == win_label,
-                       f"portfolio_{lev}x_returns"] = value
+
+                df.loc[df[args.datecol] == win_label, f"portfolio_{lev}x"] = value
+
+    # ensure date column retains datetime dtype
+    returns_df[args.datecol] = pd.to_datetime(returns_df[args.datecol])
+    annualised_returns_df[args.datecol] = pd.to_datetime(
+        annualised_returns_df[args.datecol]
+    )
+
+    value_cols = [f"portfolio_{lev}x" for lev in args.leverage]
+    returns_df[value_cols] = returns_df[value_cols].astype(float)
+    annualised_returns_df[value_cols] = annualised_returns_df[value_cols].astype(float)
 
     # -------------------------------------------------------------- #
     # 4. summary: bust proportions                                   #
     # -------------------------------------------------------------- #
     total_windows = len(windows)
-    summary_df = pd.DataFrame({
-        'leverage'   : list(bust_counter.keys()),
-        'bust_ratio' : [bust_counter[lev] / total_windows
-                        for lev in bust_counter]
-    })
+    summary_df = pd.DataFrame(
+        {
+            "leverage": list(bust_counter.keys()),
+            "bust_ratio": [bust_counter[lev] / total_windows for lev in bust_counter],
+        }
+    )
 
     # -------------------------------------------------------------- #
     # 5. persist results                                             #
     # -------------------------------------------------------------- #
-    returns_df.to_csv(name_run_output('returns', args.out,
-                                      args.leverage, "csv"), index=False)
-    annualised_returns_df.to_csv(name_run_output('ann_returns', args.out,
-                                                 args.leverage, "csv"),
-                                 index=False)
-    summary_df.to_csv(name_run_output('bust_summary', args.out,
-                                      args.leverage, "csv"), index=False)
+    returns_df.to_csv(
+        name_run_output("returns", args.out, args.leverage, "csv"), index=False
+    )
+    annualised_returns_df.to_csv(
+        name_run_output("ann_returns", args.out, args.leverage, "csv"), index=False
+    )
+    summary_df.to_csv(
+        name_run_output("bust_summary", args.out, args.leverage, "csv"), index=False
+    )
 
-    if args.plot:
+    if getattr(args, "plot", False):
         fig = boxplot_returns(
-            returns_df= returns_df,
-            portfolio_cols= [f"portfolio_{lev}x_returns" for lev in args.leverage],
-            showfliers=False
+            returns_df=returns_df,
+            portfolio_cols=[f"portfolio_{lev}x" for lev in args.leverage],
+            showfliers=False,
         )
         fig.show()
-        fig.savefig(name_run_output('returns',args.out, args.leverage, "png"))
+        fig.savefig(name_run_output("returns", args.out, args.leverage, "png"))
         plt.close(fig)
 
-        log_fig = boxplot_returns(returns_df, 
-                                  [f"portfolio_{lev}x_returns" for lev in args.leverage],
-                                  log = True)
-        log_fig.savefig(name_run_output('returns_log',args.out, args.leverage, "png"))    
+        log_fig = boxplot_returns(
+            returns_df, [f"portfolio_{lev}x" for lev in args.leverage], log=True
+        )
+        log_fig.savefig(name_run_output("returns_log", args.out, args.leverage, "png"))
         plt.close(log_fig)
 
         ann_fig = boxplot_returns(
-            returns_df= annualised_returns_df,
-            portfolio_cols= [f"portfolio_{lev}x_returns" for lev in args.leverage],
+            returns_df=annualised_returns_df,
+            portfolio_cols=[f"portfolio_{lev}x" for lev in args.leverage],
             showfliers=False,
-            label = 'annualized return')
-        ann_fig.savefig(name_run_output('returns_annualized',args.out, args.leverage, "png"))    
+            label="annualized return",
+        )
+        ann_fig.savefig(
+            name_run_output("returns_annualized", args.out, args.leverage, "png")
+        )
         plt.close(ann_fig)
+    return returns_df, annualised_returns_df, summary_df
+
 
 if __name__ == "__main__":
     p = argparse.ArgumentParser()

--- a/src/portfolio/__init__.py
+++ b/src/portfolio/__init__.py
@@ -8,25 +8,23 @@ from .core import (
     identify_windows,
     calc_window_returns,
     simulate_window,
+    detect_bust,
     simulate_leveraged_series,
     window_return,
     annualise,
-    
 )
 
-from .report import(
-        boxplot_returns,
+from .report import (
+    boxplot_returns,
 )
 
-from .utils import(
-    to_native,
-    name_run_output
-)
+from .utils import to_native, name_run_output
 
 __all__ = [
     "simulate_portfolio",
     "identify_windows",
     "calc_window_returns",
+    "detect_bust",
 ]
 
 __version__ = "0.1.0"

--- a/src/your_package/__init__.py
+++ b/src/your_package/__init__.py
@@ -1,0 +1,5 @@
+"""Helper package exposing the CLI main function for tests."""
+
+from .your_module import main
+
+__all__ = ["main"]

--- a/src/your_package/your_module.py
+++ b/src/your_package/your_module.py
@@ -1,0 +1,17 @@
+"""Compatibility wrapper so tests can import :func:`main`.
+
+This module dynamically loads ``main.py`` from the project root and exposes
+its ``main`` function.  The test suite imports ``your_package.your_module`` to
+access the CLI entry point without relying on the package layout.
+"""
+
+from importlib import util
+from pathlib import Path
+
+_path = Path(__file__).resolve().parents[2] / "main.py"
+spec = util.spec_from_file_location("_bt_main", _path)
+_module = util.module_from_spec(spec)
+spec.loader.exec_module(_module)
+main = _module.main
+
+__all__ = ["main"]


### PR DESCRIPTION
## Summary
- move bust detection logic to `core.detect_bust`
- update CLI to use `detect_bust` and return result data frames
- ensure date and value columns have appropriate dtypes
- slice inclusive ranges in main loop and annualise over 252 days
- expose CLI via small helper package for tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68586608f2d883249b708103af0e7a8c