### PR TITLE
Add manual returns integration test

### DIFF
--- a/tests/test_manual_returns_example.py
+++ b/tests/test_manual_returns_example.py
@@ -1,0 +1,47 @@
+import pandas as pd
+import pandas.testing as pdt
+from argparse import Namespace
+
+from your_package.your_module import main
+
+
+def test_manual_returns_single_window(tmp_path):
+    # create example CSV
+    df = pd.DataFrame({
+        "date": ["2025-01", "2025-02", "2025-03", "2025-04"],
+        "sp_real_price": [100.0, 104.0, 97.76, 86.0288],
+    })
+    csv_path = tmp_path / "prices.csv"
+    df.to_csv(csv_path, index=False)
+
+    args = Namespace(
+        csv=str(csv_path),
+        window=len(df) - 1,  # single window covering all rows
+        leverage=[1, 2, 10],
+        datecol="date",
+        pricecol="sp_real_price",
+        out=str(tmp_path),
+    )
+
+    returns_df, _, summary_df = main(args)
+
+    expected = pd.DataFrame({
+        "date": pd.to_datetime(["2025-01"]),
+        "portfolio_1x": [-0.139712],
+        "portfolio_2x": [-0.277696],
+        "portfolio_10x": [0.0],
+    })
+
+    pdt.assert_frame_equal(returns_df.reset_index(drop=True), expected)
+
+    expected_summary = pd.DataFrame(
+        {
+            "leverage": [1, 2, 10],
+            "bust_ratio": [0.0, 0.0, 1.0],
+        }
+    )
+
+    pdt.assert_frame_equal(
+        summary_df.sort_values("leverage").reset_index(drop=True),
+        expected_summary,
+    )


### PR DESCRIPTION
## Summary
- create integration test verifying manual portfolio returns for a single window
- assert 10x leverage portfolio goes bust rather than disabling bust detection

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68586b0f0fe083248ec5f0538fad2b2b