### PR TITLE
Fix spelling in simulate_portfolio docstring

### DIFF
--- a/src/portfolio/core.py
+++ b/src/portfolio/core.py
@@ -156,7 +156,7 @@ doctest.run_docstring_examples(calc_window_returns, globals())
 
 
 def simulate_portfolio(df, leverage=1, dividend=False, rebalance_period=1):
-    """DEPRICATED
+    """DEPRECATED
     Simulate portfolio value given an S&P real-price column.
 
     Examples


### PR DESCRIPTION
## Summary
- update spelling of 'DEPRECATED' in docstring for `simulate_portfolio`

## Testing
- `ruff check src/portfolio/core.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68587188e5c88324b70e97bd02118253