### PR TITLE
Add data frequency parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ bash scripts/setup_env.sh
 pytest -q
 
 # 4  Run the CLI on your own CSV
-python main.py data/sp500_real.csv --window 252 --leverage 1 2 --plot
+python main.py data/sp500_real.csv --window 252 --leverage 1 2 --freq month --plot
 ```
 
 ## Command-Line Interface (CLI) Usage
@@ -61,9 +61,13 @@ python main.py data/processed/data_for_futures.csv --window 240 --leverage 0.5 0
   Example: `--leverage 1.0 2.0 3.0`  
   **Default:** `1.0 2.0`
 
-- `--datecol <str>`  
-  Name of the column to use for date labels.  
+- `--datecol <str>`
+  Name of the column to use for date labels.
   **Default:** `"date"`
+
+- `--freq {day,month,year}`
+  Frequency of the input data. Determines how annualised returns are calculated.
+  **Default:** `month`
 
 
 - `--out <filename>`  
@@ -76,7 +80,7 @@ python main.py data/processed/data_for_futures.csv --window 240 --leverage 0.5 0
 ### Example Usage
 
 ```bash
-python main.py data/sp500_real.csv --window 252 --leverage 1.0 2.0 3.0 --plot --out results/returns.csv
+python main.py data/sp500_real.csv --window 252 --leverage 1.0 2.0 3.0 --freq month --plot --out results/returns.csv
 ```
 
 ## Project Layout

--- a/main.py
+++ b/main.py
@@ -10,6 +10,7 @@ if __name__ == "__main__":
     p.add_argument("--leverage", nargs="+", type=float, default=[1.0, 2.0])
     p.add_argument("--datecol", default="date")
     p.add_argument("--pricecol", default="sp_real_price")
+    p.add_argument("--freq", choices=["day", "month", "year"], default="month")
     p.add_argument("--out", default="rolling_returns.csv")
     p.add_argument("--plot", action="store_true")
     main(p.parse_args())

--- a/src/portfolio/cli.py
+++ b/src/portfolio/cli.py
@@ -5,10 +5,18 @@ from .core import identify_windows, simulate_window, detect_bust
 from .report import boxplot_returns
 from .utils import name_run_output
 
+FREQ_TO_PERIODS = {
+    "day": 252,
+    "month": 12,
+    "year": 1,
+}
+
 
 def main(args):
     data = pd.read_csv(args.csv)
     data.sort_values(args.datecol, inplace=True)
+
+    periods_per_year = FREQ_TO_PERIODS.get(args.freq, 12)
 
     windows = identify_windows(data, window_size=args.window)
 
@@ -33,7 +41,7 @@ def main(args):
                 window_ann = 0.0
             else:
                 window_ret = V_path[-1] / V_path[0] - 1.0
-                years = (len(prices) - 1) / 252
+                years = (len(prices) - 1) / periods_per_year
                 window_ann = (V_path[-1] / V_path[0]) ** (1 / years) - 1.0
 
             win_label = data.loc[start_idx, args.datecol]

--- a/src/portfolio/core.py
+++ b/src/portfolio/core.py
@@ -79,11 +79,20 @@ def window_return(series: pd.Series, start: int, end: int) -> float:
     return series.iat[end] / series.iat[start] - 1.0
 
 
-def annualise(r: float, n_days: int, periods_per_year: int = 252) -> float:
+def annualise(r: float, n_periods: int, periods_per_year: int) -> float:
+    """Geometrically annualise ``r`` over ``n_periods``.
+
+    Parameters
+    ----------
+    r : float
+        Total return over the period.
+    n_periods : int
+        Number of observed periods used to generate ``r``.
+    periods_per_year : int
+        How many of those periods constitute one year.
     """
-    Geometric annualisation.
-    """
-    return (1.0 + r) ** (periods_per_year / n_days) - 1.0
+
+    return (1.0 + r) ** (periods_per_year / n_periods) - 1.0
 
 
 def calc_window_returns(

--- a/tests/test_main_integration.py
+++ b/tests/test_main_integration.py
@@ -18,43 +18,46 @@ def naive_sim(prices, leverage, V0=1.0):
     return np.array(V)
 
 
-def build_expected_frames(df_prices, window_size, leverage, datecol, pricecol):
+FREQ_TO_PERIODS = {"day": 252, "month": 12, "year": 1}
+
+
+def build_expected_frames(df_prices, window_size, leverage, datecol, pricecol, freq):
     """Return returns_df, annual_df, summary_df calculated independently."""
     # 1. windows
     windows = [[i, i + window_size] for i in range(len(df_prices) - window_size)]
 
     # 2. returns containers
     returns_rows = []
-    ann_rows     = []
-    busts        = 0
+    ann_rows = []
+    busts = 0
 
     for start, end in windows:
-        window_prices = df_prices.iloc[start:end + 1][pricecol]
-        V_path        = naive_sim(window_prices.values, leverage)
-        busted        = (V_path <= 0).any()
+        window_prices = df_prices.iloc[start : end + 1][pricecol]
+        V_path = naive_sim(window_prices.values, leverage)
+        busted = (V_path <= 0).any()
         if busted:
             busts += 1
             window_ret = 0.0
             window_ann = 0.0
         else:
             window_ret = V_path[-1] / V_path[0] - 1.0
-            years      = (len(window_prices) - 1) / 252
+            periods_per_year = FREQ_TO_PERIODS[freq]
+            years = (len(window_prices) - 1) / periods_per_year
             window_ann = (V_path[-1] / V_path[0]) ** (1 / years) - 1.0
 
         win_label = df_prices.iloc[start][datecol]
-        returns_rows.append({datecol: win_label,
-                             f"portfolio_{leverage}x": window_ret})
-        ann_rows.append({datecol: win_label,
-                         f"portfolio_{leverage}x": window_ann})
+        returns_rows.append({datecol: win_label, f"portfolio_{leverage}x": window_ret})
+        ann_rows.append({datecol: win_label, f"portfolio_{leverage}x": window_ann})
 
     returns_df = pd.DataFrame(returns_rows)
-    annual_df  = pd.DataFrame(ann_rows)
-    summary_df = pd.DataFrame({"leverage": [leverage],
-                               "bust_ratio": [busts / len(windows)]})
+    annual_df = pd.DataFrame(ann_rows)
+    summary_df = pd.DataFrame(
+        {"leverage": [leverage], "bust_ratio": [busts / len(windows)]}
+    )
     # ensure identical column order
     ordered_cols = [datecol, f"portfolio_{leverage}x"]
-    returns_df  = returns_df[ordered_cols]
-    annual_df   = annual_df[ordered_cols]
+    returns_df = returns_df[ordered_cols]
+    annual_df = annual_df[ordered_cols]
 
     return returns_df, annual_df, summary_df
 
@@ -63,10 +66,12 @@ def build_expected_frames(df_prices, window_size, leverage, datecol, pricecol):
 def test_main_integration(tmp_path: Path):
     # 1. create a small price CSV
     csv_path = tmp_path / "prices.csv"
-    df = pd.DataFrame({
-        "date": pd.to_datetime(["2024-01-01", "2024-01-02", "2024-01-03"]),
-        "settle": [100.0, 110.0, 100.0],
-    })
+    df = pd.DataFrame(
+        {
+            "date": pd.to_datetime(["2024-01-01", "2024-01-02", "2024-01-03"]),
+            "settle": [100.0, 110.0, 100.0],
+        }
+    )
     df.to_csv(csv_path, index=False)
 
     # 2. build args object similar to CLI Namespace
@@ -76,7 +81,8 @@ def test_main_integration(tmp_path: Path):
         leverage=[1.5],
         datecol="date",
         pricecol="settle",
-        out=str(tmp_path)  # required by name_run_output but unused here
+        out=str(tmp_path),  # required by name_run_output but unused here
+        freq="day",
     )
 
     # 3. call main (must return the three data frames)
@@ -84,8 +90,7 @@ def test_main_integration(tmp_path: Path):
 
     # 4. compute expected frames independently
     exp_ret, exp_ann, exp_sum = build_expected_frames(
-        df, window_size=1, leverage=1.5,
-        datecol="date", pricecol="settle"
+        df, window_size=1, leverage=1.5, datecol="date", pricecol="settle", freq="day"
     )
 
     # 5. assert equality (order-insensitive on index)
@@ -97,5 +102,6 @@ def test_main_integration(tmp_path: Path):
         ann_df.sort_values("date").reset_index(drop=True),
         exp_ann.sort_values("date").reset_index(drop=True),
     )
-    pdt.assert_frame_equal(summary_df.reset_index(drop=True),
-                           exp_sum.reset_index(drop=True))
+    pdt.assert_frame_equal(
+        summary_df.reset_index(drop=True), exp_sum.reset_index(drop=True)
+    )

--- a/tests/test_manual_returns_example.py
+++ b/tests/test_manual_returns_example.py
@@ -7,10 +7,12 @@ from your_package.your_module import main
 
 def test_manual_returns_single_window(tmp_path):
     # create example CSV
-    df = pd.DataFrame({
-        "date": ["2025-01", "2025-02", "2025-03", "2025-04"],
-        "sp_real_price": [100.0, 104.0, 97.76, 86.0288],
-    })
+    df = pd.DataFrame(
+        {
+            "date": ["2025-01", "2025-02", "2025-03", "2025-04"],
+            "sp_real_price": [100.0, 104.0, 97.76, 86.0288],
+        }
+    )
     csv_path = tmp_path / "prices.csv"
     df.to_csv(csv_path, index=False)
 
@@ -21,16 +23,19 @@ def test_manual_returns_single_window(tmp_path):
         datecol="date",
         pricecol="sp_real_price",
         out=str(tmp_path),
+        freq="month",
     )
 
     returns_df, _, summary_df = main(args)
 
-    expected = pd.DataFrame({
-        "date": pd.to_datetime(["2025-01"]),
-        "portfolio_1x": [-0.139712],
-        "portfolio_2x": [-0.277696],
-        "portfolio_10x": [0.0],
-    })
+    expected = pd.DataFrame(
+        {
+            "date": pd.to_datetime(["2025-01"]),
+            "portfolio_1x": [-0.139712],
+            "portfolio_2x": [-0.277696],
+            "portfolio_10x": [0.0],
+        }
+    )
 
     pdt.assert_frame_equal(returns_df.reset_index(drop=True), expected)
 


### PR DESCRIPTION
## Summary
- support day/month/year data via new `--freq` CLI option
- compute annualised returns using selected frequency
- document the new option
- update integration tests for configurable frequency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6858759691dc832483bba1aa79205812