### PR TITLE
Fix CLI date sorting and parsing

### DIFF
--- a/src/portfolio/cli.py
+++ b/src/portfolio/cli.py
@@ -15,6 +15,7 @@ FREQ_TO_PERIODS = {
 def main(args):
     data = pd.read_csv(args.csv)
     data.sort_values(args.datecol, inplace=True)
+    data.reset_index(drop=True, inplace=True)
 
     periods_per_year = FREQ_TO_PERIODS.get(args.freq, 12)
 
@@ -44,7 +45,7 @@ def main(args):
                 years = (len(prices) - 1) / periods_per_year
                 window_ann = (V_path[-1] / V_path[0]) ** (1 / years) - 1.0
 
-            win_label = data.loc[start_idx, args.datecol]
+            win_label = data.iloc[start_idx][args.datecol]
 
             for df, value in (
                 (returns_df, window_ret),
@@ -55,10 +56,11 @@ def main(args):
 
                 df.loc[df[args.datecol] == win_label, f"portfolio_{lev}x"] = value
 
-    returns_df[args.datecol] = pd.to_datetime(returns_df[args.datecol])
-    annualised_returns_df[args.datecol] = pd.to_datetime(
-        annualised_returns_df[args.datecol]
-    )
+    if args.datecol == "date":
+        returns_df[args.datecol] = pd.to_datetime(returns_df[args.datecol])
+        annualised_returns_df[args.datecol] = pd.to_datetime(
+            annualised_returns_df[args.datecol]
+        )
 
     value_cols = [f"portfolio_{lev}x" for lev in args.leverage]
     returns_df[value_cols] = returns_df[value_cols].astype(float)

--- a/tests/test_main_integration.py
+++ b/tests/test_main_integration.py
@@ -2,11 +2,14 @@
 import pandas as pd
 import numpy as np
 import pandas.testing as pdt
+import matplotlib.pyplot as plt
+import pytest
 from argparse import Namespace
 from pathlib import Path
 
 # import the main you want to test
-from your_package.your_module import main
+# import the CLI entry point under test
+from portfolio.cli import main
 
 
 # ---------- helper: independent leverage simulation ---------------- #
@@ -105,3 +108,185 @@ def test_main_integration(tmp_path: Path):
     pdt.assert_frame_equal(
         summary_df.reset_index(drop=True), exp_sum.reset_index(drop=True)
     )
+
+
+def test_multiple_leverage_columns(tmp_path: Path):
+    df = pd.DataFrame(
+        {
+            "date": pd.date_range("2024-01-01", periods=4, freq="D"),
+            "price": [100.0, 105.0, 103.0, 106.0],
+        }
+    )
+    csv = tmp_path / "prices.csv"
+    df.to_csv(csv, index=False)
+
+    args = Namespace(
+        csv=str(csv),
+        window=2,
+        leverage=[1.0, 2.0, 3.0],
+        datecol="date",
+        pricecol="price",
+        out=str(tmp_path),
+        freq="day",
+    )
+
+    returns_df, ann_df, _ = main(args)
+
+    expected_cols = ["date"] + [f"portfolio_{lev}x" for lev in args.leverage]
+    assert list(returns_df.columns) == expected_cols
+    assert list(ann_df.columns) == expected_cols
+    assert not returns_df.isna().any().any()
+    assert not ann_df.isna().any().any()
+
+
+def test_unsorted_input_sorted_output(tmp_path: Path):
+    df = pd.DataFrame(
+        {
+            "date": pd.to_datetime(["2024-01-03", "2024-01-01", "2024-01-02"]),
+            "price": [120.0, 100.0, 110.0],
+        }
+    )
+    csv = tmp_path / "prices.csv"
+    df.to_csv(csv, index=False)
+
+    args = Namespace(
+        csv=str(csv),
+        window=1,
+        leverage=[1.0],
+        datecol="date",
+        pricecol="price",
+        out=str(tmp_path),
+        freq="day",
+    )
+
+    returns_df, ann_df, _ = main(args)
+
+    sorted_df = df.sort_values("date").reset_index(drop=True)
+    exp_ret, exp_ann, _ = build_expected_frames(
+        sorted_df, 1, 1.0, "date", "price", "day"
+    )
+    pdt.assert_frame_equal(
+        returns_df.sort_values("date").reset_index(drop=True),
+        exp_ret.sort_values("date").reset_index(drop=True),
+    )
+    pdt.assert_frame_equal(
+        ann_df.sort_values("date").reset_index(drop=True),
+        exp_ann.sort_values("date").reset_index(drop=True),
+    )
+
+
+def test_plot_option_creates_files(tmp_path: Path, monkeypatch):
+    df = pd.DataFrame(
+        {
+            "date": pd.date_range("2024-01-01", periods=3, freq="D"),
+            "price": [100.0, 101.0, 102.0],
+        }
+    )
+    csv = tmp_path / "prices.csv"
+    df.to_csv(csv, index=False)
+
+    figs = []
+
+    def dummy_boxplot_returns(*args, **kwargs):
+        fig = plt.figure()
+        figs.append(fig)
+        return fig
+
+    monkeypatch.setattr("portfolio.cli.boxplot_returns", dummy_boxplot_returns)
+    monkeypatch.setattr(
+        "portfolio.cli.name_run_output",
+        lambda name, out, lev, ftype: str(tmp_path / f"{name}.{ftype}"),
+    )
+
+    args = Namespace(
+        csv=str(csv),
+        window=1,
+        leverage=[1.0],
+        datecol="date",
+        pricecol="price",
+        out=str(tmp_path),
+        freq="day",
+        plot=True,
+    )
+
+    main(args)
+
+    assert len(figs) == 3
+    for fname in ["returns.png", "returns_log.png", "returns_annualized.png"]:
+        assert (tmp_path / fname).exists()
+
+
+def test_bust_detection(tmp_path: Path):
+    df = pd.DataFrame(
+        {
+            "date": pd.date_range("2024-01-01", periods=3, freq="D"),
+            "price": [100.0, 90.0, 90.0],
+        }
+    )
+    csv = tmp_path / "prices.csv"
+    df.to_csv(csv, index=False)
+
+    args = Namespace(
+        csv=str(csv),
+        window=1,
+        leverage=[10.0],
+        datecol="date",
+        pricecol="price",
+        out=str(tmp_path),
+        freq="day",
+    )
+
+    returns_df, _, summary_df = main(args)
+
+    assert returns_df.iloc[0, 1] == 0.0
+    assert summary_df.loc[0, "bust_ratio"] == 0.5
+
+
+def test_date_column_override(tmp_path: Path):
+    df = pd.DataFrame(
+        {
+            "ts": ["2024-01", "2024-02", "2024-03"],
+            "price": [100.0, 110.0, 120.0],
+        }
+    )
+    csv = tmp_path / "prices.csv"
+    df.to_csv(csv, index=False)
+
+    args = Namespace(
+        csv=str(csv),
+        window=1,
+        leverage=[1.0],
+        datecol="ts",
+        pricecol="price",
+        out=str(tmp_path),
+        freq="month",
+    )
+
+    returns_df, _, _ = main(args)
+
+    assert list(returns_df.columns)[0] == "ts"
+    assert returns_df["ts"].tolist() == ["2024-01", "2024-02"]
+
+
+def test_missing_price_column(tmp_path: Path):
+    df = pd.DataFrame(
+        {
+            "date": ["d1", "d2"],
+            "price": [1.0, 2.0],
+        }
+    )
+    csv = tmp_path / "prices.csv"
+    df.to_csv(csv, index=False)
+
+    args = Namespace(
+        csv=str(csv),
+        window=1,
+        leverage=[1.0],
+        datecol="date",
+        pricecol="missing",  # does not exist
+        out=str(tmp_path),
+        freq="day",
+    )
+
+    with pytest.raises(KeyError):
+        main(args)

--- a/tests/test_manual_returns_example.py
+++ b/tests/test_manual_returns_example.py
@@ -2,7 +2,7 @@ import pandas as pd
 import pandas.testing as pdt
 from argparse import Namespace
 
-from your_package.your_module import main
+from portfolio.cli import main
 
 
 def test_manual_returns_single_window(tmp_path):


### PR DESCRIPTION
## Summary
- ensure CLI resets index after sorting
- only convert date column to datetime when using default `date`
- keep custom date columns as provided by the user

## Testing
- `pytest -q`
- `python -m venv .venv && source .venv/bin/activate && pip install -e . && pip install pytest && pytest -q` *(fails: Operation cancelled by user while installing dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_68587b2ab778832488759ffbc2a72bc5