### PR TITLE
Add dividend support to CLI

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,6 +11,7 @@ if __name__ == "__main__":
     p.add_argument("--datecol", default="date")
     p.add_argument("--pricecol", default="sp_real_price")
     p.add_argument("--freq", choices=["day", "month", "year"], default="month")
+    p.add_argument("--dividendcol", default=None)
     p.add_argument("--out", default="rolling_returns.csv")
     p.add_argument("--plot", action="store_true")
     main(p.parse_args())

--- a/tests/test_cli_dividend_feature.py
+++ b/tests/test_cli_dividend_feature.py
@@ -1,0 +1,33 @@
+import pandas as pd
+import pytest
+from argparse import Namespace
+from portfolio.cli import main
+
+
+def test_dividend_portfolio_added(tmp_path):
+    df = pd.DataFrame(
+        {
+            "date": pd.date_range("2024-01-01", periods=3, freq="D"),
+            "price": [100.0, 110.0, 105.0],
+            "div": [0.0, 0.5, 0.5],
+        }
+    )
+    csv = tmp_path / "prices.csv"
+    df.to_csv(csv, index=False)
+
+    args = Namespace(
+        csv=str(csv),
+        window=1,
+        leverage=[1],
+        datecol="date",
+        pricecol="price",
+        dividendcol="div",
+        out=str(tmp_path),
+        freq="day",
+    )
+
+    returns_df, _, _ = main(args)
+
+    expected = [0.105, -0.04090909090909094]
+    assert list(returns_df.columns) == ["date", "portfolio_1x", "1x_dividend"]
+    assert returns_df["1x_dividend"].tolist() == pytest.approx(expected)


### PR DESCRIPTION
## Summary
- add `--dividendcol` CLI option
- compute special `1x_dividend` portfolio when a dividend column is supplied
- expose new argument in `main.py`
- test dividend portfolio creation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685881d68ee883249d56ec098a9a0b9e