### PR TITLE
Implement proportional underlying returns

### DIFF
--- a/src/portfolio/core.py
+++ b/src/portfolio/core.py
@@ -177,7 +177,7 @@ def simulate_window_dividend(prices: pd.Series, dividends: pd.Series) -> np.ndar
 
 
 def underlying_return(prices: pd.Series) -> float:
-    """Return absolute change in price over ``prices``.
+    """Return proportional change in price over ``prices``.
 
     Parameters
     ----------
@@ -187,10 +187,10 @@ def underlying_return(prices: pd.Series) -> float:
     Returns
     -------
     float
-        ``prices`` end value minus start value.
+        Proportional change ``(end / start) - 1``.
     """
 
-    return prices.iloc[-1] - prices.iloc[0]
+    return prices.iloc[-1] / prices.iloc[0] - 1.0
 
 
 def simulate_portfolio(df, leverage=1, dividend=False, rebalance_period=1):

--- a/tests/test_underlying_portfolio.py
+++ b/tests/test_underlying_portfolio.py
@@ -32,7 +32,7 @@ def test_underlying_portfolio_added(tmp_path):
     prices = df["price"].tolist()
     path = naive_sim(prices, 1.0)
     exp_port = [path[1] / path[0] - 1.0, path[2] / path[1] - 1.0]
-    underlying_returns = [prices[1] - prices[0], prices[2] - prices[1]]
+    underlying_returns = [prices[1] / prices[0] - 1.0, prices[2] / prices[1] - 1.0]
     expected = pd.DataFrame(
         {
             "date": df["date"].iloc[:2].tolist(),


### PR DESCRIPTION
## Summary
- compute underlying return as proportional change
- adapt tests for new definition

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68588d476f688324a75b85effa99cdee