### PR TITLE
Add start/end date columns to returns_df

### DIFF
--- a/tests/test_dividend_portfolio.py
+++ b/tests/test_dividend_portfolio.py
@@ -29,6 +29,8 @@ def test_dividend_portfolio_added(tmp_path):
     )
 
     returns_df, _, _ = main(args)
+    start_col = f"start_{args.datecol}"
+    end_col = f"end_{args.datecol}"
 
     prices = df["price"].tolist()
     divs = df["div"].tolist()
@@ -40,14 +42,15 @@ def test_dividend_portfolio_added(tmp_path):
     ]
     expected = pd.DataFrame(
         {
-            "date": df["date"].iloc[:2].tolist(),
+            start_col: df["date"].iloc[:2].dt.strftime("%Y-%m-%d").tolist(),
+            end_col: df["date"].iloc[1:3].dt.strftime("%Y-%m-%d").tolist(),
             "portfolio_1x": exp_port,
             "1x_dividend": div_returns,
         }
     )
 
     pdt.assert_frame_equal(
-        returns_df.sort_values("date").reset_index(drop=True),
-        expected.sort_values("date").reset_index(drop=True),
+        returns_df.sort_values(start_col).reset_index(drop=True),
+        expected.sort_values(start_col).reset_index(drop=True),
     )
     assert "1x_dividend" in returns_df.columns

--- a/tests/test_manual_returns_example.py
+++ b/tests/test_manual_returns_example.py
@@ -27,10 +27,13 @@ def test_manual_returns_single_window(tmp_path):
     )
 
     returns_df, _, summary_df = main(args)
+    start_col = f"start_{args.datecol}"
+    end_col = f"end_{args.datecol}"
 
     expected = pd.DataFrame(
         {
-            "date": pd.to_datetime(["2025-01"]),
+            start_col: ["2025-01"],
+            end_col: ["2025-04"],
             "portfolio_1x": [-0.139712],
             "portfolio_2x": [-0.277696],
             "portfolio_10x": [0.0],

--- a/tests/test_underlying_portfolio.py
+++ b/tests/test_underlying_portfolio.py
@@ -28,6 +28,8 @@ def test_underlying_portfolio_added(tmp_path):
     )
 
     returns_df, _, _ = main(args)
+    start_col = f"start_{args.datecol}"
+    end_col = f"end_{args.datecol}"
 
     prices = df["price"].tolist()
     path = naive_sim(prices, 1.0)
@@ -35,14 +37,15 @@ def test_underlying_portfolio_added(tmp_path):
     underlying_returns = [prices[1] - prices[0], prices[2] - prices[1]]
     expected = pd.DataFrame(
         {
-            "date": df["date"].iloc[:2].tolist(),
+            start_col: df["date"].iloc[:2].dt.strftime("%Y-%m-%d").tolist(),
+            end_col: df["date"].iloc[1:3].dt.strftime("%Y-%m-%d").tolist(),
             "portfolio_1x": exp_port,
             "underlying": underlying_returns,
         }
     )
 
     pdt.assert_frame_equal(
-        returns_df.sort_values("date").reset_index(drop=True),
-        expected.sort_values("date").reset_index(drop=True),
+        returns_df.sort_values(start_col).reset_index(drop=True),
+        expected.sort_values(start_col).reset_index(drop=True),
     )
     assert "underlying" in returns_df.columns


### PR DESCRIPTION
## Summary
- add `_format_label` util in CLI for tidy date strings
- capture window start and end labels in simulation output
- update tests for start/end columns

## Testing
- `black src/ tests/`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68588d0e72848324ab9cf85532747e96