### PR TITLE
Update plots to include optional portfolios

### DIFF
--- a/src/portfolio/cli.py
+++ b/src/portfolio/cli.py
@@ -163,24 +163,28 @@ def main(args):
     )
 
     if getattr(args, "plot", False):
+        plot_cols = [f"portfolio_{lev}x" for lev in args.leverage]
+        if include_underlying:
+            plot_cols.append("underlying")
+        if dividend_column is not None:
+            plot_cols.append("1x_dividend")
+
         fig = boxplot_returns(
             returns_df=returns_df,
-            portfolio_cols=[f"portfolio_{lev}x" for lev in args.leverage],
+            portfolio_cols=plot_cols,
             showfliers=False,
         )
         fig.show()
         fig.savefig(name_run_output("returns", args.out, args.leverage, "png"))
         plt.close(fig)
 
-        log_fig = boxplot_returns(
-            returns_df, [f"portfolio_{lev}x" for lev in args.leverage], log=True
-        )
+        log_fig = boxplot_returns(returns_df, plot_cols, log=True)
         log_fig.savefig(name_run_output("returns_log", args.out, args.leverage, "png"))
         plt.close(log_fig)
 
         ann_fig = boxplot_returns(
             returns_df=annualised_returns_df,
-            portfolio_cols=[f"portfolio_{lev}x" for lev in args.leverage],
+            portfolio_cols=plot_cols,
             showfliers=False,
             label="annualized return",
         )

--- a/tests/test_plot_optional_columns.py
+++ b/tests/test_plot_optional_columns.py
@@ -1,0 +1,52 @@
+import pandas as pd
+import matplotlib.pyplot as plt
+from argparse import Namespace
+
+from portfolio.cli import main
+
+
+def test_plot_includes_optional_cols(tmp_path, monkeypatch):
+    df = pd.DataFrame(
+        {
+            "date": pd.date_range("2024-01-01", periods=3, freq="D"),
+            "price": [100.0, 101.0, 102.0],
+            "div": [0.0, 1.0, 1.0],
+        }
+    )
+    csv = tmp_path / "prices.csv"
+    df.to_csv(csv, index=False)
+
+    called_cols = []
+
+    def dummy_boxplot_returns(*args, **kwargs):
+        if args:
+            # first positional is returns_df, second is portfolio_cols
+            portfolio_cols = args[1]
+        else:
+            portfolio_cols = kwargs.get("portfolio_cols")
+        called_cols.append(portfolio_cols)
+        return plt.figure()
+
+    monkeypatch.setattr("portfolio.cli.boxplot_returns", dummy_boxplot_returns)
+    monkeypatch.setattr(
+        "portfolio.cli.name_run_output",
+        lambda name, out, lev, ftype: str(tmp_path / f"{name}.{ftype}"),
+    )
+
+    args = Namespace(
+        csv=str(csv),
+        window=1,
+        leverage=[1.0],
+        datecol="date",
+        pricecol="price",
+        dividendcol="div",
+        underlying=True,
+        out=str(tmp_path),
+        freq="day",
+        plot=True,
+    )
+
+    main(args)
+
+    expected = ["portfolio_1.0x", "underlying", "1x_dividend"]
+    assert all(cols == expected for cols in called_cols)


### PR DESCRIPTION
## Summary
- ensure CLI boxplots include underlying and 1x dividend portfolios when requested
- test that optional columns are passed to plotting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68588eed98b48324af50e5c0e64a55a0