### PR TITLE
Remove date parsing

### DIFF
--- a/src/portfolio/cli.py
+++ b/src/portfolio/cli.py
@@ -20,38 +20,18 @@ FREQ_TO_PERIODS = {
 
 
 def _format_label(value, freq):
-    """Format a date-like value according to the frequency.
+    """Return ``value`` unchanged.
 
-    Parameters
-    ----------
-    value : Any
-        The value to format. Can be a string, :class:`~pandas.Timestamp`, or
-        missing (``NaT``/``None``).
-    freq : {"day", "month", "year"}
-        Frequency that determines the output precision.
-
-    Returns
-    -------
-    str | pandas.NA
-        Formatted label or :data:`pandas.NA` if the value is not a valid
-        timestamp.
+    This CLI previously attempted to parse dates and format them according
+    to ``freq``. For full generality we now keep whatever objects appear in
+    the date column so that arbitrary strings are supported.
     """
 
-    ts = pd.to_datetime(value, errors="coerce")
-    if pd.isna(ts):
-        return pd.NA
-
-    if freq == "year":
-        return ts.strftime("%Y")
-    if freq == "month":
-        return ts.strftime("%Y-%m")
-    return ts.strftime("%Y-%m-%d")
+    return value
 
 
 def main(args):
     data = pd.read_csv(args.csv)
-    data.sort_values(args.datecol, inplace=True)
-    data.reset_index(drop=True, inplace=True)
 
     periods_per_year = FREQ_TO_PERIODS.get(args.freq, 12)
 

--- a/tests/test_cli_format_label.py
+++ b/tests/test_cli_format_label.py
@@ -2,7 +2,7 @@ import pandas as pd
 from portfolio.cli import _format_label
 
 
-def test_format_label_handles_invalid_dates():
-    assert pd.isna(_format_label(pd.NaT, "day"))
-    assert pd.isna(_format_label(None, "month"))
-    assert pd.isna(_format_label("not-a-date", "day"))
+def test_format_label_is_identity():
+    assert _format_label(pd.NaT, "day") is pd.NaT
+    assert _format_label(None, "month") is None
+    assert _format_label("not-a-date", "day") == "not-a-date"

--- a/tests/test_main_integration.py
+++ b/tests/test_main_integration.py
@@ -170,7 +170,7 @@ def test_multiple_leverage_columns(tmp_path: Path):
     assert not ann_df.isna().any().any()
 
 
-def test_unsorted_input_sorted_output(tmp_path: Path):
+def test_unsorted_input_preserves_order(tmp_path: Path):
     df = pd.DataFrame(
         {
             "date": pd.to_datetime(["2024-01-03", "2024-01-01", "2024-01-02"]),
@@ -194,17 +194,16 @@ def test_unsorted_input_sorted_output(tmp_path: Path):
     start_col = f"start_{args.datecol}"
     end_col = f"end_{args.datecol}"
 
-    sorted_df = df.sort_values("date").reset_index(drop=True)
     exp_ret, exp_ann, _ = build_expected_frames(
-        sorted_df, 1, 1.0, "date", "price", "day"
+        df.reset_index(drop=True), 1, 1.0, "date", "price", "day"
     )
     pdt.assert_frame_equal(
-        returns_df.sort_values(start_col).reset_index(drop=True),
-        exp_ret.sort_values(start_col).reset_index(drop=True),
+        returns_df.reset_index(drop=True),
+        exp_ret.reset_index(drop=True),
     )
     pdt.assert_frame_equal(
-        ann_df.sort_values(start_col).reset_index(drop=True),
-        exp_ann.sort_values(start_col).reset_index(drop=True),
+        ann_df.reset_index(drop=True),
+        exp_ann.reset_index(drop=True),
     )
 
 


### PR DESCRIPTION
## Summary
- treat date values as-is in the CLI
- keep row order instead of sorting by dates
- adjust tests to match new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685ad03d41dc8324aa84ced18ead6c00