### PR TITLE
Add portfolio summary statistics

### DIFF
--- a/src/portfolio/report.py
+++ b/src/portfolio/report.py
@@ -29,3 +29,76 @@ def boxplot_returns(
     fig = ax.get_figure()
     fig.tight_layout()
     return fig
+
+
+def summary_statistics(
+    returns_df: pd.DataFrame,
+    annualised_df: pd.DataFrame,
+    bust_df: pd.DataFrame,
+    sharpe_dict: dict[str, list[float]],
+) -> pd.DataFrame:
+    """Aggregate window statistics for each portfolio column.
+
+    Parameters
+    ----------
+    returns_df : DataFrame
+        Table of total returns for each window.
+    annualised_df : DataFrame
+        Table of annualised returns (CAGR) for each window.
+    bust_df : DataFrame
+        Summary of bust proportions with columns ``leverage`` and ``bust_ratio``.
+    sharpe_dict : dict[str, list[float]]
+        Mapping of portfolio column name to a list of Sharpe ratios for each
+        window.
+
+    Returns
+    -------
+    DataFrame
+        One row per portfolio column containing the metrics described in the
+        specification.
+    """
+
+    start_col, end_col = returns_df.columns[:2]
+    portfolio_cols = [c for c in returns_df.columns if c not in (start_col, end_col)]
+
+    # map columns like ``portfolio_1x`` to bust ratios
+    def _col_name(lev):
+        text = str(lev)
+        if text.endswith(".0"):
+            text = text[:-2]
+        return f"portfolio_{text}x"
+
+    bust_map = {_col_name(row["leverage"]): row["bust_ratio"] for _, row in bust_df.iterrows()}
+
+    stats = []
+    for col in portfolio_cols:
+        series_ret = pd.to_numeric(returns_df[col], errors="coerce")
+        series_cagr = pd.to_numeric(annualised_df[col], errors="coerce")
+
+        mean_ret = series_ret.mean()
+        iqr_ret = series_ret.quantile(0.75) - series_ret.quantile(0.25)
+        mean_cagr = series_cagr.mean()
+        std_cagr = series_cagr.std()
+        bust_ratio = bust_map.get(col, 0.0)
+
+        sharpe_vals = sharpe_dict.get(col, [])
+        avg_sharpe = float(pd.Series(sharpe_vals).mean()) if sharpe_vals else 0.0
+
+        stats.append(
+            {
+                "portfolio": col,
+                "mean_total_return": mean_ret,
+                "iqr_total_return": iqr_ret,
+                "mean_cagr": mean_cagr,
+                "std_cagr": std_cagr,
+                "bust_ratio": bust_ratio,
+                "avg_sharpe": avg_sharpe,
+                "min_total_return": series_ret.min(),
+                "max_total_return": series_ret.max(),
+            }
+        )
+
+    return pd.DataFrame(stats)
+
+
+__all__ = ["boxplot_returns", "summary_statistics"]

--- a/tests/test_dividend_portfolio.py
+++ b/tests/test_dividend_portfolio.py
@@ -28,7 +28,7 @@ def test_dividend_portfolio_added(tmp_path):
         freq="day",
     )
 
-    returns_df, _, _ = main(args)
+    returns_df, _, _, _ = main(args)
     start_col = f"start_{args.datecol}"
     end_col = f"end_{args.datecol}"
 

--- a/tests/test_main_integration.py
+++ b/tests/test_main_integration.py
@@ -113,8 +113,8 @@ def test_main_integration(tmp_path: Path):
         freq="day",
     )
 
-    # 3. call main (must return the three data frames)
-    returns_df, ann_df, summary_df = main(args)
+    # 3. call main (must return the data frames)
+    returns_df, ann_df, summary_df, _ = main(args)
     start_col = f"start_{args.datecol}"
     end_col = f"end_{args.datecol}"
 
@@ -157,7 +157,7 @@ def test_multiple_leverage_columns(tmp_path: Path):
         freq="day",
     )
 
-    returns_df, ann_df, _ = main(args)
+    returns_df, ann_df, _, _ = main(args)
     start_col = f"start_{args.datecol}"
     end_col = f"end_{args.datecol}"
 
@@ -190,7 +190,7 @@ def test_unsorted_input_preserves_order(tmp_path: Path):
         freq="day",
     )
 
-    returns_df, ann_df, _ = main(args)
+    returns_df, ann_df, _, _ = main(args)
     start_col = f"start_{args.datecol}"
     end_col = f"end_{args.datecol}"
 
@@ -268,7 +268,7 @@ def test_bust_detection(tmp_path: Path):
         freq="day",
     )
 
-    returns_df, _, summary_df = main(args)
+    returns_df, _, summary_df, _ = main(args)
     start_col = f"start_{args.datecol}"
     end_col = f"end_{args.datecol}"
 
@@ -296,7 +296,7 @@ def test_date_column_override(tmp_path: Path):
         freq="month",
     )
 
-    returns_df, _, _ = main(args)
+    returns_df, _, _, _ = main(args)
     start_col = f"start_{args.datecol}"
     end_col = f"end_{args.datecol}"
 

--- a/tests/test_manual_returns_example.py
+++ b/tests/test_manual_returns_example.py
@@ -26,7 +26,7 @@ def test_manual_returns_single_window(tmp_path):
         freq="month",
     )
 
-    returns_df, _, summary_df = main(args)
+    returns_df, _, summary_df, _ = main(args)
     start_col = f"start_{args.datecol}"
     end_col = f"end_{args.datecol}"
 

--- a/tests/test_summary_statistics.py
+++ b/tests/test_summary_statistics.py
@@ -1,0 +1,37 @@
+import pandas as pd
+import pandas.testing as pdt
+
+from portfolio.report import summary_statistics
+
+
+def test_summary_statistics_basic():
+    returns_df = pd.DataFrame({
+        "start": ["s1", "s2"],
+        "end": ["e1", "e2"],
+        "portfolio_1x": [0.1, 0.2],
+        "portfolio_2x": [0.2, 0.4],
+    })
+    annual_df = pd.DataFrame({
+        "start": ["s1", "s2"],
+        "end": ["e1", "e2"],
+        "portfolio_1x": [0.1, 0.2],
+        "portfolio_2x": [0.2, 0.4],
+    })
+    bust_df = pd.DataFrame({"leverage": [1, 2], "bust_ratio": [0.0, 0.5]})
+    sharpe = {"portfolio_1x": [1.0, 2.0], "portfolio_2x": [2.0, 3.0]}
+
+    out = summary_statistics(returns_df, annual_df, bust_df, sharpe)
+
+    expected = pd.DataFrame({
+        "portfolio": ["portfolio_1x", "portfolio_2x"],
+        "mean_total_return": [0.15, 0.3],
+        "iqr_total_return": [0.05, 0.1],
+        "mean_cagr": [0.15, 0.3],
+        "std_cagr": [0.070710678, 0.141421356],
+        "bust_ratio": [0.0, 0.5],
+        "avg_sharpe": [1.5, 2.5],
+        "min_total_return": [0.1, 0.2],
+        "max_total_return": [0.2, 0.4],
+    })
+
+    pdt.assert_frame_equal(out.round(6), expected.round(6))

--- a/tests/test_underlying_portfolio.py
+++ b/tests/test_underlying_portfolio.py
@@ -27,7 +27,7 @@ def test_underlying_portfolio_added(tmp_path):
         underlying=True,
     )
 
-    returns_df, _, _ = main(args)
+    returns_df, _, _, _ = main(args)
     start_col = f"start_{args.datecol}"
     end_col = f"end_{args.datecol}"
 


### PR DESCRIPTION
## Summary
- compute per-portfolio summary statistics
- expose functionality from CLI and save to CSV
- return summary statistics from CLI
- test new reporting helper and adapt existing tests
- rename daily Sharpe calc variables to be frequency-agnostic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685b0e993c848324a3b05c98ef4171cb